### PR TITLE
Fix npm peer dependency warn (grunt-license) and error (grunt-pngmin)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "grunt-contrib-less": "^1.0.1",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-license": "^0.1.5",
     "grunt-licensechecker": "^0.1.3",
     "grunt-newer": "^0.8.0",
-    "grunt-pngmin": "^0.6.2",
+    "grunt-pngmin": "^1.0.2",
     "grunt-shell": "^1.1.2",
     "less-plugin-autoprefix": "^1.4.2",
     "load-grunt-tasks": "^1.0.0"


### PR DESCRIPTION
When attempting to install the npm deps locally, I ran into two issues. One was a missing peer dependency spec for grunt-license and the other was an error caused by the grunt-pngmin package. To fix the warn I added grunt-license to package.json; to fix the error I updated the grunt-pngmin package to latest. The version jumped from 0.6.2 -> 1.0.2, but I ran both **grunt** and **grunt release** and didn't notice any breaking changes.
